### PR TITLE
Add Composer tools for diff generation

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,4 +1,4 @@
-name: docker-make vim
+name: Development
 
 on:
   push:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,4 +1,4 @@
-name: make install
+name: Install
 
 on:
   push:

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -1,4 +1,4 @@
-name: make optional
+name: Optional
 
 on:
   push:
@@ -48,3 +48,30 @@ jobs:
         env:
           INTERACTIVE: 0
         run: ${{ matrix.installer }} ${{ matrix.target }}
+
+  composer:
+    strategy:
+      matrix:
+        version: ['20.04']
+        php: [8]
+        composer: [2]
+        extensions: [zip]
+        target: [composer-changelogs, composer-lock-diff]
+    runs-on: ubuntu-${{ matrix.version }}
+    name: ${{ matrix.target }} @Ubuntu ${{ matrix.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install PHP ${{ matrix.php }}, Composer ${{ matrix.composer }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          tools: composer:v${{ matrix.composer }}
+      - name: Setup GitHub SSH
+        uses: MrSquaare/ssh-setup-action@v1
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          private-key-name: id_rsa
+      - name: Composer - ${{ matrix.target }}
+        run: make INTERACTIVE=0 --trace --debug ${{ matrix.target }};

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,14 @@ DOCKER_COMPOSE := $(shell command -v docker-compose || echo /usr/local/bin/docke
 DNSMASQ = /etc/dnsmasq.d
 
 DOCKER_COMPOSE_DEVELOPMENT := $(shell echo "$$HOME/development")
+DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE := $(shell dev workspace 2>/dev/null || echo "$(DOCKER_COMPOSE_DEVELOPMENT)/workspace")
+DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN = $(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE)/bin
 DOCKER_COMPOSE_DEVELOPMENT_PROFILE := $(shell echo "$$HOME/.zshrc-development")
 DOCKER_COMPOSE_DEVELOPMENT_DNSMASQ := $(shell echo "$(DNSMASQ)/docker-compose-development.conf")
+
+COMPOSER := $(shell command -v composer || echo "$(DOCKER_COMPOSE_DEVELOPMENT)/bin/composer")
+COMPOSER_LOCK_DIFF := $(shell command -v composer-lock-diff || echo /usr/local/bin/composer-lock-diff)
+COMPOSER_CHANGELOGS := $(shell command -v composer-changelogs || echo /usr/local/bin/composer-changelogs)
 
 ZSH := $(shell command -v zsh || echo /usr/bin/zsh)
 ZSHRC := $(shell echo "$$HOME/.zshrc")
@@ -419,6 +425,8 @@ tmuxinator_completion: | $(TMUXINATOR_COMPLETION_ZSH) $(TMUXINATOR_COMPLETION_BA
 all: | \
 	install \
 	brave \
+	composer-lock-diff \
+	composer-changelogs \
 	firefox \
 	gimp \
 	google-chrome \
@@ -446,3 +454,25 @@ $(GIMP):
 	sudo apt install gimp -y
 
 gimp: | $(GIMP)
+
+$(COMPOSER): | $(DOCKER_COMPOSE_DEVELOPMENT)
+composer: | $(COMPOSER)
+
+$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN): $(DOCKER_COMPOSE_DEVELOPMENT)
+	mkdir -p "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)"
+
+$(COMPOSER_LOCK_DIFF): | $(COMPOSER) $(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)
+	$(COMPOSER) global require davidrjonas/composer-lock-diff
+	echo 'composer global exec -- composer-lock-diff $$@;\nexit $$?;' > "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-lock-diff"
+	sudo ln -s "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-lock-diff" "$(COMPOSER_LOCK_DIFF)"
+	sudo chmod +x $(COMPOSER_LOCK_DIFF)
+
+composer-lock-diff: | $(COMPOSER_LOCK_DIFF)
+
+$(COMPOSER_CHANGELOGS): | $(COMPOSER) $(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)
+	$(COMPOSER) global require pyrech/composer-changelogs
+	echo 'composer global exec -- composer-changelogs $$@;\nexit $$?;' > "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-changelogs"
+	sudo ln -s "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-changelogs" "$(COMPOSER_CHANGELOGS)"
+	sudo chmod +x $(COMPOSER_CHANGELOGS)
+
+composer-changelogs: | $(COMPOSER_CHANGELOGS)

--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ $(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN): $(DOCKER_COMPOSE_DEVELOPMENT)
 
 $(COMPOSER_LOCK_DIFF): | $(COMPOSER) $(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)
 	$(COMPOSER) global require davidrjonas/composer-lock-diff
-	echo 'composer global exec -- composer-lock-diff $$@;\nexit $$?;' > "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-lock-diff"
+	echo '$(COMPOSER) global exec -- composer-lock-diff $$@;\nexit $$?;' > "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-lock-diff"
 	sudo ln -s "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-lock-diff" "$(COMPOSER_LOCK_DIFF)"
 	sudo chmod +x $(COMPOSER_LOCK_DIFF)
 
@@ -471,7 +471,7 @@ composer-lock-diff: | $(COMPOSER_LOCK_DIFF)
 
 $(COMPOSER_CHANGELOGS): | $(COMPOSER) $(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)
 	$(COMPOSER) global require pyrech/composer-changelogs
-	echo 'composer global exec -- composer-changelogs $$@;\nexit $$?;' > "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-changelogs"
+	echo '$(COMPOSER) global exec -- composer-changelogs $$@;\nexit $$?;' > "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-changelogs"
 	sudo ln -s "$(DOCKER_COMPOSE_DEVELOPMENT_WORKSPACE_BIN)/composer-changelogs" "$(COMPOSER_CHANGELOGS)"
 	sudo chmod +x $(COMPOSER_CHANGELOGS)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current supported operating systems:
 
 # Installation
 
-[![make install](https://github.com/elgentos/setup/workflows/make%20install/badge.svg)](https://github.com/elgentos/setup/actions?query=workflow%3A%22make+install%22)
+[![Install](https://github.com/elgentos/setup/workflows/Install/badge.svg)](https://github.com/elgentos/setup/actions?query=workflow%3A%22Install%22)
 
 
 Run the following:
@@ -38,6 +38,7 @@ The following software has been installed:
 
 - [AWS CLI](https://gist.github.com/JeroenBoersma/87e29fd4aa06ec42216c80a6e3649fa5) w/💘
 - [Bash](https://www.gnu.org/software/bash/)
+- [Composer](https://getcomposer.org/)
 - [cURL](https://curl.haxx.se/)
 - [Docker](https://www.docker.com/)
 - [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)
@@ -55,7 +56,7 @@ The following software has been installed:
 
 # Optional
 
-[![make optional](https://github.com/elgentos/setup/workflows/make%20optional/badge.svg)](https://github.com/elgentos/setup/actions?query=workflow%3A%22make+optional%22)
+[![Optional](https://github.com/elgentos/setup/workflows/Optional/badge.svg)](https://github.com/elgentos/setup/actions?query=workflow%3A%22Optional%22)
 
 To cherry-pick optional software, use the following targets:
 
@@ -71,6 +72,8 @@ To cherry-pick optional software, use the following targets:
 
 ## Tools
 
+- [`composer-lock-diff`](https://packagist.org/packages/davidrjonas/composer-lock-diff)
+- [`composer-changelogs`](https://packagist.org/packages/pyrech/composer-changelogs)
 - [`ssg`](https://github.com/elgentos/ssg-js) (SSH GUI)
 - [`symlinks`](https://tracker.debian.org/pkg/symlinks)
 - [`tmux`](https://tracker.debian.org/pkg/tmux)
@@ -87,7 +90,7 @@ The following adds `gimp`, `symlinks` and `ssg` to the installation.
 
 # Development
 
-[![docker-make vim](https://github.com/elgentos/setup/workflows/docker-make%20vim/badge.svg)](https://github.com/elgentos/setup/actions?query=workflow%3A%22docker-make+vim%22)
+[![Development](https://github.com/elgentos/setup/workflows/Development/badge.svg)](https://github.com/elgentos/setup/actions?query=workflow%3A%22Develpoment%22)
 
 In order to locally test a Make target, run the following:
 

--- a/docker-make
+++ b/docker-make
@@ -12,7 +12,7 @@ COMMANDS=(
   "useradd -u $(id -u "$USER") -g $(id -g "$USER") --groups app,sudo app"
   'chown app:app /home/app'
   'passwd --delete app'
-  "su app -c 'make INTERACTIVE=0 --trace --debug ${@}'"
+  "su app -c 'make INTERACTIVE=0 --trace --debug ${*}'"
 )
 
 [[ "$TINKER" == "" ]] || COMMANDS+=("$TINKER")


### PR DESCRIPTION
### Fixes

Allow multiple `./docker-make` targets at-once

The array of arguments was incorrectly expanded. By using `${*}`
instead, all arguments become individual targets for `make`.

### Additions

Add Composer tooling:
- `composer-lock-diff`
- `composer-changelogs`

Closes #3 

### Changes

Rename workflows

The workflow names were inheritted from a personal project. They are
changed because they did not accurately reflect the tooling they
represent.
    
Their name is made more generic, because the workflows have become an
umbrella for multiple ways of installation.