### PR TITLE
Select networks by eliminating superfluous columns

### DIFF
--- a/chat/slack.make
+++ b/chat/slack.make
@@ -3,7 +3,7 @@ $(SLACK): | $(CURL)
 	sudo dpkg --list | awk '{ print $2 }' | grep -qE 'kde-cli-tools|kde-runtime|trash-cli|libglib2.0-bin|gvfs-bin' \
 		|| sudo apt install gvfs-bin -y
 	$(CURL) -L $(shell $(CURL) -L https://slack.com/intl/en-nl/downloads/instructions/ubuntu \
-			| grep -oe 'https://downloads.slack-edge.com/linux_releases/slack-desktop-[0-9]*.[0-9]*.[0-9]*-amd64.deb') \
+			| grep -oe 'https://downloads.slack-edge.com/releases/linux/[0-9]*.[0-9]*.[0-9]*/prod/x64/slack-desktop-[0-9]*.[0-9]*.[0-9]*-amd64.deb') \
 		--output /tmp/slack.deb
 	sudo dpkg --install /tmp/slack.deb
 	rm -f /tmp/slack.deb

--- a/development/docker-compose-development-dnsmasq.make
+++ b/development/docker-compose-development-dnsmasq.make
@@ -13,7 +13,7 @@ $(DOCKER_COMPOSE_DEVELOPMENT_DNSMASQ): | $(DNSMASQ) $(DOCKER_COMPOSE_DEVELOPMENT
 	echo nameserver 127.0.0.1 | sudo tee -a /etc/resolv.conf
 	echo nameserver 1.1.1.1   | sudo tee -a /etc/resolv.conf
 	echo nameserver 9.9.9.9   | sudo tee -a /etc/resolv.conf
-	for con in $(shell nmcli con show --active | tail -n +2 | awk '{ print $$1 }'); do \
+	nmcli con show --active | tail -n +2 | awk '!($$(NF)="")!($$(NF-1)="")!($$(NF-2)="")' | while read con; do \
 		nmcli con mod "$$con" +ipv4.dns "$(shell $(IP) route | grep -E 'docker[0-9]' | awk '{ print $$9 }' | grep '.')"; \
 		nmcli con down "$$con"; \
 		nmcli con up "$$con"; \

--- a/dns/dnsmasq.make
+++ b/dns/dnsmasq.make
@@ -11,7 +11,7 @@ $(DNSMASQ): | $(BASH) $(UFW)
 			&& sudo service network-manager restart \
 			|| echo 'Skipping NetworkManager restart.'
 	sleep 2
-	for con in $(shell nmcli con show --active | tail -n +2 | awk '{ print $$1 }'); do \
+	for con in $(shell nmcli con show --active | tail -n +2 | awk '!($$(NF)="")!($$(NF-1)="")!($$(NF-2)="")'); do \
 		nmcli con mod "$$con" ipv4.ignore-auto-dns yes; \
 		nmcli con mod "$$con" ipv4.dns '127.0.0.1 1.1.1.1 9.9.9.9'; \
 		nmcli con down "$$con"; \

--- a/dns/dnsmasq.make
+++ b/dns/dnsmasq.make
@@ -11,7 +11,7 @@ $(DNSMASQ): | $(BASH) $(UFW)
 			&& sudo service network-manager restart \
 			|| echo 'Skipping NetworkManager restart.'
 	sleep 2
-	for con in "$(shell nmcli con show --active | tail -n +2 | awk '!($$(NF)="")!($$(NF-1)="")!($$(NF-2)="")')"; do \
+	nmcli con show --active | tail -n +2 | awk '!($$(NF)="")!($$(NF-1)="")!($$(NF-2)="")' | while read con; do \
 		nmcli con mod "$$con" ipv4.ignore-auto-dns yes; \
 		nmcli con mod "$$con" ipv4.dns '127.0.0.1 1.1.1.1 9.9.9.9'; \
 		nmcli con down "$$con"; \

--- a/dns/dnsmasq.make
+++ b/dns/dnsmasq.make
@@ -11,7 +11,7 @@ $(DNSMASQ): | $(BASH) $(UFW)
 			&& sudo service network-manager restart \
 			|| echo 'Skipping NetworkManager restart.'
 	sleep 2
-	for con in $(shell nmcli con show --active | tail -n +2 | awk '!($$(NF)="")!($$(NF-1)="")!($$(NF-2)="")'); do \
+	for con in "$(shell nmcli con show --active | tail -n +2 | awk '!($$(NF)="")!($$(NF-1)="")!($$(NF-2)="")')"; do \
 		nmcli con mod "$$con" ipv4.ignore-auto-dns yes; \
 		nmcli con mod "$$con" ipv4.dns '127.0.0.1 1.1.1.1 9.9.9.9'; \
 		nmcli con down "$$con"; \


### PR DESCRIPTION
The output of `nmcli con show --active` is as follows:

```
NAME                UUID                                  TYPE      DEVICE  
elgentos 2.0        e11a63a9-9515-4bac-803c-430565dff83f  wifi      wlp82s0      
docker0             4d6b6730-e43f-409f-b062-ed70e3d0c9be  bridge    docker0 
```

By selecting only the first column using `awk '{print $1}'`, the name "elgentos 2.0" gets reduced to "elgentos", which breaks the installation.

By Inverting the selection, through simply removing the last 3 columns, all that remains is the actual network name.

Closes #16 