### PR TITLE
Make Dnsmasq part of the optional software

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The following software has been installed:
 - [Composer](https://getcomposer.org/)
 - [cURL](https://curl.haxx.se/)
 - [Docker](https://www.docker.com/)
-- [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)
 - [Docker compose](https://docs.docker.com/compose/)
 - [Docker compose development](https://github.com/JeroenBoersma/docker-compose-development)
 - [GIT](https://git-scm.com/)
@@ -80,6 +79,10 @@ To cherry-pick optional software, use the following targets:
 - [`tmux`](https://tracker.debian.org/pkg/tmux)
 - [`tmuxinator`](https://tracker.debian.org/pkg/tmuxinator)
 - [`tmuxinator_completion`](https://github.com/tmuxinator/tmuxinator/tree/master/completion)
+
+## Networking
+
+- [`dnsmasq`](http://www.thekelleys.org.uk/dnsmasq/doc.html)
 
 ## Example
 

--- a/development/docker-compose-development-dnsmasq.make
+++ b/development/docker-compose-development-dnsmasq.make
@@ -30,4 +30,4 @@ $(DOCKER_COMPOSE_DEVELOPMENT_DNSMASQ): | $(DNSMASQ) $(DOCKER_COMPOSE_DEVELOPMENT
 
 docker-compose-development-dnsmasq: | $(DOCKER_COMPOSE_DEVELOPMENT_DNSMASQ)
 
-install:: | docker-compose-development-dnsmasq
+optional:: | docker-compose-development-dnsmasq

--- a/dns/dnsmasq.make
+++ b/dns/dnsmasq.make
@@ -35,4 +35,4 @@ $(DNSMASQ): | $(BASH) $(UFW)
 
 dnsmasq: | $(DNSMASQ)
 
-install:: | dnsmasq
+optional:: | dnsmasq


### PR DESCRIPTION
The Dnsmasq installation is currently prone to breaking the workstation
mid-setup. While it is in this unstable state, the setup treats it as
optional, rather than required.