### PR TITLE
Install docker compose CLI plugin

### DIFF
--- a/container/docker.make
+++ b/container/docker.make
@@ -3,7 +3,7 @@ $(DOCKER): | $(LSB_RELEASE) $(CURL) $(SOFTWARE_PROPERTIES_COMMON)
 	$(CURL) -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 	sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(shell $(LSB_RELEASE) -cs) stable"
 	sudo apt update -y
-	sudo apt install docker-ce docker-ce-cli containerd.io -y
+	sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 	sudo usermod -aG docker $(shell whoami)
 	sudo systemctl enable docker
 


### PR DESCRIPTION
This adds the `docker compose` subcommands. See https://docs.docker.com/compose/install/compose-plugin/#install-the-plugin-manually