### PR TITLE
Create dir if it does not exist

### DIFF
--- a/cloud/aws.make
+++ b/cloud/aws.make
@@ -3,6 +3,7 @@ $(AWS): | $(GIT) $(DOCKER) $(SSH_KEY)
 		https://gist.github.com/87e29fd4aa06ec42216c80a6e3649fa5.git \
 		$(GITPROJECTS)/aws-cli
 	chmod +x $(GITPROJECTS)/aws-cli/aws.sh
+	mkdir -p $(dirname $(AWS))
 	sudo ln -s $(GITPROJECTS)/aws-cli/aws.sh $(AWS)
 	@echo $(INTERACTIVE) | grep -q '1' && sudo $(AWS) --version || echo -n ''
 


### PR DESCRIPTION
On a clean 22.04 install, apparently /usr/local/bin does not exist